### PR TITLE
delete extra semicolon

### DIFF
--- a/src/spline.h
+++ b/src/spline.h
@@ -597,7 +597,7 @@ std::vector<double> spline::solve(double y, bool ignore_extrapolation) const
     }
 
     return x;
-};
+}
 
 
 #ifdef HAVE_SSTREAM


### PR DESCRIPTION
I noticed a warning when compiling in my ROS2 node. It appears to have an extra semicolon.

Warning:
```
/.../lib/spline/src/spline.h:600:2: warning: extra ‘;’ [-Wpedantic]
  600 | };
      | 
```