### PR TITLE
linear interpolation works with just two points

### DIFF
--- a/src/spline.h
+++ b/src/spline.h
@@ -244,7 +244,10 @@ void spline::set_points(const std::vector<double>& x,
                         spline_type type)
 {
     assert(x.size()==y.size());
-    assert(x.size()>=3);
+    if(type==linear)
+        assert(x.size()>=2);
+    else
+        assert(x.size()>=3);
     // not-a-knot with 3 points has many solutions
     if(m_left==not_a_knot || m_right==not_a_knot)
         assert(x.size()>=4);


### PR DESCRIPTION
There is no need to fail if we have just two points, but selected linear interpolation